### PR TITLE
Fix rocm-llvm dead symlinks

### DIFF
--- a/pkgs/rocm-packages/overrides.nix
+++ b/pkgs/rocm-packages/overrides.nix
@@ -96,6 +96,14 @@ applyOverrides {
         zlib
         zstd
       ];
+
+      installPhase =
+        (prevAttrs.installPhase or "")
+        + ''
+          # Dead symlink(s).
+          chmod -R +w $out/lib
+          rm -f $out/lib/llvm/bin/flang
+        '';
     };
 
   rocminfo =


### PR DESCRIPTION
These dangling links have become an error in the latest nixpkgs.