### PR TITLE
Add hooks to propagate dependencies

### DIFF
--- a/pkgs/rocm-packages/default.nix
+++ b/pkgs/rocm-packages/default.nix
@@ -8,6 +8,8 @@ let
   runfileMetadata = builtins.fromJSON (builtins.readFile ./runfile-metadata.json);
   fixedPoint = final: { inherit callPackage lib runfileMetadata; };
   composed = lib.composeManyExtensions [
+    # Hooks
+    (import ./hooks.nix)
     # Base package set.
     (import ./components.nix)
     # Overrides (adding dependencies, etc.)

--- a/pkgs/rocm-packages/generic.nix
+++ b/pkgs/rocm-packages/generic.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    rocmPackages.markForRocmRootHook
     rsync
   ];
 
@@ -48,10 +49,12 @@ stdenv.mkDerivation rec {
   ] ++ (map (dep: rocmPackages.${dep}) filteredDeps);
 
   installPhase = ''
+    runHook preInstall
     mkdir $out
     for bundleSrc in ${lib.concatStringsSep " " components}; do
       rsync -a ${src}/component-rocm/$bundleSrc/content/opt/rocm-${version}/* $out/
     done
+    runHook postInstall
   '';
 
   autoPatchelfIgnoreMissingDeps = [

--- a/pkgs/rocm-packages/hooks.nix
+++ b/pkgs/rocm-packages/hooks.nix
@@ -1,0 +1,17 @@
+final: prev: {
+  markForRocmRootHook = final.callPackage (
+    { makeSetupHook }:
+    makeSetupHook { name = "mark-for-rocm-root-hook"; } ./mark-for-rocm-root-hook.sh
+  ) { };
+
+  setupRocmHook = (
+    final.callPackage (
+      { makeSetupHook }:
+      makeSetupHook {
+        name = "setup-rocm-hook";
+
+        substitutions.setupRocmHook = placeholder "out";
+      } ./setup-rocm-hook.sh
+    ) { }
+    );
+}

--- a/pkgs/rocm-packages/joins.nix
+++ b/pkgs/rocm-packages/joins.nix
@@ -24,6 +24,7 @@ final: prev: {
       version = final.hipcc.version;
 
       nativeBuildInputs = [
+        final.markForRocmRootHook
         makeWrapper
         rsync
       ];
@@ -33,6 +34,7 @@ final: prev: {
         rocm-device-libs
         hsa-rocr
         rocminfo
+        setupRocmHook
       ];
 
       dontUnpack = true;
@@ -43,7 +45,7 @@ final: prev: {
         mkdir -p $out
 
         for path in ${hipcc} ${hip-dev} ${hip-runtime-amd} ${rocm-opencl}; do
-          rsync -a $path/ $out/
+          rsync -a --exclude=nix-support $path/ $out/
         done
 
         chmod -R u+w $out
@@ -86,6 +88,7 @@ final: prev: {
     version = final.hipcc.version;
 
     nativeBuildInputs = [
+      final.markForRocmRootHook
       makeWrapper
       rsync
     ];
@@ -98,7 +101,7 @@ final: prev: {
       mkdir -p $out
 
       for path in ${openmp-extras-dev} ${openmp-extras-runtime}; do
-        rsync -a $path/lib/llvm/ $out/
+        rsync --exclude=nix-support -a $path/lib/llvm/ $out/
       done
 
       runHook postInstall

--- a/pkgs/rocm-packages/mark-for-rocm-root-hook.sh
+++ b/pkgs/rocm-packages/mark-for-rocm-root-hook.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+
+# Based on mark-for-cuda-root-hook.
+
+(( ${hostOffset:?} == -1 && ${targetOffset:?} == 0)) || return 0
+
+echo "Sourcing mark-for-rocm-root-hook" >&2
+
+markForROCM_ROOT() {
+    mkdir -p "${prefix:?}/nix-support"
+    local markerPath="$prefix/nix-support/include-in-rocm-root"
+
+    # Return early if the file already exists.
+    [[ -f "$markerPath" ]] && return 0
+
+    # Always create the file, even if it's empty, since setup-cuda-hook relies on its existence.
+    # However, only populate it if strictDeps is not set.
+    touch "$markerPath"
+
+    # Return early if strictDeps is set.
+    [[ -n "${strictDeps-}" ]] && return 0
+
+    # Populate the file with the package name and output.
+    echo "${pname:?}-${output:?}" > "$markerPath"
+}
+
+fixupOutputHooks+=(markForROCM_ROOT)

--- a/pkgs/rocm-packages/setup-rocm-hook.sh
+++ b/pkgs/rocm-packages/setup-rocm-hook.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+
+# Based on setup-cuda-hook.
+
+# Only run the hook from nativeBuildInputs
+(( "$hostOffset" == -1 && "$targetOffset" == 0)) || return 0
+
+guard=Sourcing
+reason=
+
+[[ -n ${rocmSetupHookOnce-} ]] && guard=Skipping && reason=" because the hook has been propagated more than once"
+
+if (( "${NIX_DEBUG:-0}" >= 1 )) ; then
+    echo "$guard hostOffset=$hostOffset targetOffset=$targetOffset setup-rocm-hook$reason" >&2
+else
+    echo "$guard setup-rocm-hook$reason" >&2
+fi
+
+[[ "$guard" = Sourcing ]] || return 0
+
+declare -g rocmSetupHookOnce=1
+declare -Ag rocmHostPathsSeen=()
+declare -Ag rocmOutputToPath=()
+
+extendrocmHostPathsSeen() {
+    (( "${NIX_DEBUG:-0}" >= 1 )) && echo "extendrocmHostPathsSeen $1" >&2
+
+    local markerPath="$1/nix-support/include-in-rocm-root"
+    [[ ! -f "${markerPath}" ]] && return 0
+    [[ -v rocmHostPathsSeen[$1] ]] && return 0
+
+    rocmHostPathsSeen["$1"]=1
+
+    # E.g. cuda_cudart-lib
+    local rocmOutputName
+    # Fail gracefully if the file is empty.
+    # One reason the file may be empty: the package was built with strictDeps set, but the current build does not have
+    # strictDeps set.
+    read -r rocmOutputName < "$markerPath" || return 0
+
+    [[ -z "$rocmOutputName" ]] && return 0
+
+    local oldPath="${rocmOutputToPath[$rocmOutputName]-}"
+    [[ -n "$oldPath" ]] && echo "extendrocmHostPathsSeen: warning: overwriting $rocmOutputName from $oldPath to $1" >&2
+    rocmOutputToPath["$rocmOutputName"]="$1"
+}
+addEnvHooks "$targetOffset" extendrocmHostPathsSeen
+
+propagateRocmLibraries() {
+    (( "${NIX_DEBUG:-0}" >= 1 )) && echo "propagateRocmLibraries: rocmPropagateToOutput=$rocmPropagateToOutput rocmHostPathsSeen=${!rocmHostPathsSeen[*]}" >&2
+
+    [[ -z "${rocmPropagateToOutput-}" ]] && return 0
+
+    mkdir -p "${!rocmPropagateToOutput}/nix-support"
+    # One'd expect this should be propagated-bulid-build-deps, but that doesn't seem to work
+    echo "@setupRocmHook@" >> "${!rocmPropagateToOutput}/nix-support/propagated-native-build-inputs"
+
+    local propagatedBuildInputs=( "${!rocmHostPathsSeen[@]}" )
+    for output in $(getAllOutputNames) ; do
+        if [[ ! "$output" = "$rocmPropagateToOutput" ]] ; then
+            appendToVar propagatedBuildInputs "${!output}"
+        fi
+        break
+    done
+
+    # One'd expect this should be propagated-host-host-deps, but that doesn't seem to work
+    printWords "${propagatedBuildInputs[@]}" >> "${!rocmPropagateToOutput}/nix-support/propagated-build-inputs"
+}
+postFixupHooks+=(propagateRocmLibraries)


### PR DESCRIPTION
This change adds hooks to propagate ROCm dependencies, similar to `cudaPackages` does in nixpkgs. `mark-for-rocm-root-hook` marks ROCm dependencies. These dependencies are then used by `setup-rocm-hook` to propagate ROCm dependencies that were build inputs.

Using this machinery, we can let the `torch.cxxdev` output propagate any ROCm dependencies that were used to build Torch. Then downstream users of Torch (e.g. compute kernels) do not have to specify those dependencies in their build inputs anymore.